### PR TITLE
Changed 'maven' to 'maven-publish'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 // Matches values in recent template from React Native 0.59 / 0.60
 // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-play-services",
+  "name": "react-native-play-services-maven-publish",
   "title": "React Native Play Services",
   "version": "1.0.4",
   "description": "Use Google Play Services API in React Native.",


### PR DESCRIPTION
maven, suggested to use maven-publish.

https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#removal_of_the_legacy_maven_plugin
https://stackoverflow.com/questions/69100888/plugin-with-id-maven-not-found